### PR TITLE
Fix post type check for rss feed

### DIFF
--- a/classes/class-feed-module.php
+++ b/classes/class-feed-module.php
@@ -22,6 +22,21 @@ class Pronamic_Events_FeedModule {
 		add_action( 'rss2_item', array( $this, 'rss2_item' ) );
 	}
 
+    /**
+     * Determine if the post type supports the Pronamic Events feed module.
+     *
+     * @return boolean
+     */
+    protected function is_supported_post_type() {
+        $post_type = get_query_var( 'post_type' );
+
+        if ( empty( $post_type ) ) {
+            return false;
+        }
+
+        return in_array( 'pronamic_event', (array) $post_type );
+    }
+
 	/**
 	 * RSS2 namespaces.
 	 *
@@ -30,7 +45,7 @@ class Pronamic_Events_FeedModule {
 	 * @see https://github.com/WordPress/WordPress/blob/4.9/wp-includes/feed-rss2.php#L30-L37
 	 */
 	public function rss2_ns() {
-		if ( ! post_type_supports( get_query_var( 'post_type' ), 'pronamic_event' ) ) {
+		if ( ! $this->is_supported_post_type() ) {
 			return;
 		}
 
@@ -45,7 +60,7 @@ class Pronamic_Events_FeedModule {
 	 * @see https://github.com/WordPress/WordPress/blob/4.9/wp-includes/feed-rss2.php#L113-L120
 	 */
 	public function rss2_item() {
-		if ( ! post_type_supports( get_post_type(), 'pronamic_event' ) ) {
+		if ( ! $this->is_supported_post_type() ) {
 			return;
 		}
 

--- a/classes/class-feed-module.php
+++ b/classes/class-feed-module.php
@@ -27,14 +27,20 @@ class Pronamic_Events_FeedModule {
      *
      * @return boolean
      */
-    protected function is_supported_post_type() {
-        $post_type = get_query_var( 'post_type' );
-
-        if ( empty( $post_type ) ) {
+    protected function is_supported_post_type($post_type = null) {
+        if ( ! $post_type ) {
             return false;
         }
 
-        return in_array( 'pronamic_event', (array) $post_type );
+        $post_types = (array) $post_type;
+
+        foreach ( $post_types as $post_type ) {
+            if ( post_type_supports( $post_type, 'pronamic_event' ) ) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
 	/**
@@ -45,7 +51,7 @@ class Pronamic_Events_FeedModule {
 	 * @see https://github.com/WordPress/WordPress/blob/4.9/wp-includes/feed-rss2.php#L30-L37
 	 */
 	public function rss2_ns() {
-		if ( ! $this->is_supported_post_type() ) {
+		if ( ! $this->is_supported_post_type( get_query_var( 'post_type' ) ) ) {
 			return;
 		}
 
@@ -60,7 +66,7 @@ class Pronamic_Events_FeedModule {
 	 * @see https://github.com/WordPress/WordPress/blob/4.9/wp-includes/feed-rss2.php#L113-L120
 	 */
 	public function rss2_item() {
-		if ( ! $this->is_supported_post_type() ) {
+		if ( ! $this->is_supported_post_type( get_post_type() ) ) {
 			return;
 		}
 


### PR DESCRIPTION
Fixes the error like below that is occurring when you load the author rss feed (post type query var is empty) or when the post type query var is an array.

```
PHP Fatal error:  Uncaught TypeError: Illegal offset type in /site/wp-includes/post.php:2285
Stack trace:
#0 /site/wp-content/plugins/pronamic-events/classes/class-feed-module.php(33): post_type_supports(Array, 'pronamic_event')
#1 /site/wp-includes/class-wp-hook.php(324): Pronamic_Events_FeedModule->rss2_ns('')
```